### PR TITLE
Always include shadow casting lights in local list

### DIFF
--- a/OgreMain/src/OgreSceneManager.cpp
+++ b/OgreMain/src/OgreSceneManager.cpp
@@ -364,7 +364,7 @@ void SceneManager::_populateLightList(const Vector3& position, Real radius,
         // Calc squared distance
         lt->_calcTempSquareDist(position);
 
-        if (lt->getType() == Light::LT_DIRECTIONAL)
+        if (lt->getType() == Light::LT_DIRECTIONAL || (lt->getCastShadows() && isShadowTechniqueTextureBased()))
         {
             // Always included
             destList.push_back(lt);


### PR DESCRIPTION
Culling of shadow casting lights from SceneNode's local list cause mismatch with frame shadow texture list. This breaks a texture shadowing if there are at least two spotlights that casts shadows in the scene. Here is small fix for this.